### PR TITLE
Implement audio bus system and volume controls

### DIFF
--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,0 +1,15 @@
+[gd_resource type="AudioBusLayout" format=3 uid="uid://2nqeonjpcl5u"]
+
+[resource]
+bus/1/name = &"Music"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_fx = false
+bus/1/volume_db = 0.0
+bus/1/send = &"Master"
+bus/2/name = &"SFX"
+bus/2/solo = false
+bus/2/mute = false
+bus/2/bypass_fx = false
+bus/2/volume_db = 0.0
+bus/2/send = &"Master"

--- a/project.godot
+++ b/project.godot
@@ -16,6 +16,10 @@ config/features=PackedStringArray("4.5", "Forward Plus")
 run/max_fps=60
 boot_splash/image="res://src/assets/ui/end_screen_stuff/Game_Icon.png"
 
+[audio]
+
+buses/default_bus_layout="uid://2nqeonjpcl5u"
+
 [autoload]
 
 Signalbus="*res://src/scripts/signalbus.gd"

--- a/src/scenes/UI/settings_menu.tscn
+++ b/src/scenes/UI/settings_menu.tscn
@@ -225,24 +225,24 @@ theme = SubResource("Theme_ri8ns")
 [node name="HBoxContainer2" type="HBoxContainer" parent="TextureRect/HBoxContainer/HBoxContainer"]
 layout_mode = 2
 
-[node name="audioslider" type="HSlider" parent="TextureRect/HBoxContainer/HBoxContainer/HBoxContainer2"]
+[node name="MusicSlider" type="HSlider" parent="TextureRect/HBoxContainer/HBoxContainer/HBoxContainer2"]
 custom_minimum_size = Vector2(350, 0)
 layout_mode = 2
 theme = ExtResource("8_fxfkc")
 
-[node name="Audiovalue" type="Label" parent="TextureRect/HBoxContainer/HBoxContainer/HBoxContainer2"]
+[node name="MusicValue" type="Label" parent="TextureRect/HBoxContainer/HBoxContainer/HBoxContainer2"]
 layout_mode = 2
 theme = SubResource("Theme_ri8ns")
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="TextureRect/HBoxContainer/HBoxContainer"]
 layout_mode = 2
 
-[node name="musicslider" type="HSlider" parent="TextureRect/HBoxContainer/HBoxContainer/HBoxContainer3"]
+[node name="AudioSlider" type="HSlider" parent="TextureRect/HBoxContainer/HBoxContainer/HBoxContainer3"]
 custom_minimum_size = Vector2(350, 0)
 layout_mode = 2
 theme = ExtResource("8_fxfkc")
 
-[node name="Musicvalue" type="Label" parent="TextureRect/HBoxContainer/HBoxContainer/HBoxContainer3"]
+[node name="AudioValue" type="Label" parent="TextureRect/HBoxContainer/HBoxContainer/HBoxContainer3"]
 layout_mode = 2
 theme = SubResource("Theme_ri8ns")
 

--- a/src/scenes/audio_manager.tscn
+++ b/src/scenes/audio_manager.tscn
@@ -19,51 +19,64 @@
 script = ExtResource("1_wdger")
 
 [node name="MainMusic" type="AudioStreamPlayer" parent="."]
-process_mode = 3
 stream = ExtResource("2_nvaun")
+bus = &"Music"
 
 [node name="DeathSound" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("3_ckoot")
+bus = &"SFX"
 
 [node name="PickAxeGrab" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("4_1xe7u")
+bus = &"SFX"
 
 [node name="PickaxeThrow" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("5_0d3i6")
+bus = &"SFX"
 
 [node name="PickaxeHooked" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("6_1nd4j")
 pitch_scale = 2.56
+bus = &"SFX"
 
 [node name="PickaxeBoostHit" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("7_ccaga")
+bus = &"SFX"
 
 [node name="RopePull" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("8_hwudm")
+bus = &"SFX"
 
 [node name="BackgroundMusic" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_nvaun")
 volume_db = -10.0
+bus = &"Music"
 
 [node name="GeyserWoosh" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("10_hwudm")
 volume_db = -5.0
 pitch_scale = 2.0
+bus = &"SFX"
 
 [node name="BoilingLava" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("10_ccaga")
 autoplay = true
+bus = &"SFX"
 
 [node name="LavaHiss" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("12_cldsc")
+bus = &"SFX"
 
 [node name="DwarfDeath" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("12_upv5m")
+bus = &"SFX"
 
 [node name="Jump" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("13_vt8aq")
+bus = &"SFX"
 
 [node name="RingBoost" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("14_ojpeg")
+bus = &"SFX"
 
 [connection signal="finished" from="RopePull" to="." method="_on_rope_pull_finished"]

--- a/src/scenes/boostspot.tscn
+++ b/src/scenes/boostspot.tscn
@@ -61,6 +61,7 @@ stream = ExtResource("3_ea5tw")
 volume_db = -10.0
 autoplay = true
 max_distance = 10.0
+bus = &"SFX"
 
 [connection signal="body_entered" from="boostarea" to="." method="_on_boostarea_body_entered"]
 [connection signal="body_exited" from="boostarea" to="." method="_on_boostarea_body_exited"]

--- a/src/scenes/player.tscn
+++ b/src/scenes/player.tscn
@@ -374,5 +374,6 @@ stream = ExtResource("8_4pcbe")
 volume_db = -20.0
 unit_size = 4.0
 pitch_scale = 1.5
+bus = &"SFX"
 
 [connection signal="timeout" from="utils/hook_start_time" to="." method="_on_hook_start_time_timeout"]

--- a/src/scripts/death_screen.gd
+++ b/src/scripts/death_screen.gd
@@ -16,7 +16,7 @@ func _death_called():
 
 func _on_animation_finished(anim_name: String):
 	if anim_name == "DeathScreenAnimation":
-		Signalbus.emit_signal("_dont_play_sounds_on_reload")
+		Signalbus.emit_signal("dont_play_sounds_on_reload")
 		Globalsettings.input_disabled = false
 		get_tree().paused = false
 		get_tree().reload_current_scene()

--- a/src/scripts/player.gd
+++ b/src/scripts/player.gd
@@ -334,6 +334,7 @@ func _sway_head():
 
 func _on_player_kill() -> void:
 	if !has_died:
+		speed_lines_shader.visible = false
 		has_died = true
 		#get_tree().reload_current_scene()
 		Signalbus.kill_player.emit()

--- a/src/scripts/score_screen.gd
+++ b/src/scripts/score_screen.gd
@@ -89,7 +89,6 @@ func _on_timer_2_timeout() -> void:
 	refresh()
 
 func _on_dwarf_laugh_win_sound() -> void:
-	print("Should play laugh?")
 	win_laugh.pitch_scale = randf_range(0.8, 1.2)
 	win_laugh.play()
 

--- a/src/scripts/settingsmenu.gd
+++ b/src/scripts/settingsmenu.gd
@@ -2,10 +2,10 @@ extends Control
 
 @onready var mouse_slider = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer/HSlider
 @onready var mouse_value = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer/MouseValue
-@onready var audio_slider = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer2/audioslider
-@onready var audio_value = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer2/Audiovalue
-@onready var music_slider = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer3/musicslider
-@onready var music_value = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer3/Musicvalue
+@onready var music_slider: HSlider = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer2/MusicSlider
+@onready var audio_slider: HSlider = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer3/AudioSlider
+@onready var music_value: Label = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer2/MusicValue
+@onready var audio_value: Label = $TextureRect/HBoxContainer/HBoxContainer/HBoxContainer3/AudioValue
 
 signal settings_changed()
 
@@ -44,7 +44,6 @@ func _on_music_changed(value: float) -> void:
 	Globalsettings.music_volume = value
 	music_value.text = str(value)
 	Signalbus.settings_changed.emit()
-
 
 # BACK BUTTON
 func _on_back_pressed() -> void:

--- a/src/scripts/signalbus.gd
+++ b/src/scripts/signalbus.gd
@@ -26,7 +26,7 @@ signal play_ring_boost_sound()
 signal play_jump_sound()
 signal play_dwarf_death_sound()
 signal play_dwarf_laugh_win_sound()
-signal _dont_play_sounds_on_reload()
+signal dont_play_sounds_on_reload()
 #endregion
 
 # Others


### PR DESCRIPTION
Added a default audio bus layout with separate 'Music' and 'SFX' buses. Updated all AudioStreamPlayers to use the appropriate bus. Refactored settings menu and audio manager to support independent music and SFX volume controls, including signal and variable renaming for clarity. Fixed signal naming inconsistencies and improved audio volume mapping logic.